### PR TITLE
added spatial reference system

### DIFF
--- a/transformations/Create JSON files.txt
+++ b/transformations/Create JSON files.txt
@@ -1,4 +1,4 @@
 REM Translate the Shapefile to a machine-readable JSON
-ogr2ogr -f "GeoJSON" Bikeroutes_ogr.json /path/to/portal/data/Bikeroutes3.shp
+ogr2ogr -f "GeoJSON" Bikeroutes_ogr.json /path/to/portal/data/Bikeroutes3.shp -t_srs "urn:ogc:def:crs:OGC:1.3:CRS84"
 REM Make the JSON file human readable.
 type Bikeroutes_ogr.json | python -m simplejson.tool > Bikeroutes.json


### PR DESCRIPTION
This change makes the output spatial reference system `urn:ogc:def:crs:OGC:1.3:CRS84` in order to be compatible with GitHub geojson map rendering.

Re-exporting the file and replacing the current Bikerouets.geojson with the new output will allow GitHub to render properly (instead of looking like a horizontal line running across the North Pole).
